### PR TITLE
[Feat/#92] 설정창에서 기본 알림으로 변경 시, mainView의 타이머 종료

### DIFF
--- a/TurtleNeck/TurtleNeck/Presentation/Setting/SettingView.swift
+++ b/TurtleNeck/TurtleNeck/Presentation/Setting/SettingView.swift
@@ -93,6 +93,7 @@ struct SettingView: View {
                                 notificationManager.removeNoti()
                                 
                                 if userData.notificationMode == .default {
+                                    motionManager.isConnected = false
                                     motionManager.stopUpdates()
                                     
                                     notificationManager.settingTimeNoti(state: .normal)


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
- 설정창에서 자세 측정 알림에서 기본 알림으로 변경 시, mainView의 타이머 종료 안되던 오류
### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 설정창에서 자세 측정 알림에서 기본 알림으로 변경 시, mainView의 타이머 종료 되도록 수정
### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
