### PR TITLE
[FEAT/#102] 캐릭터 알림 시간 3분에서 1분으로 수정

### DIFF
--- a/TurtleNeck/TurtleNeck/Data/Model/User.swift
+++ b/TurtleNeck/TurtleNeck/Data/Model/User.swift
@@ -23,5 +23,5 @@ struct User: Codable {
     var isNotificationOn: Bool = true // 알림 On/Off: 기본 값 On(true)
     var timeNotiCycle: Double = 15 * 60 // 시간 알림 시간: 기본 값 15분
     var badNotiCycle: Double = 10 // 나쁜 자세 유지 시간(일반 알림): 기본 값 10초
-    var worseNotiCycle: Double = 3 * 60 // 나쁜 자세 유지 시간(캐릭터 알림): 기본 값 3분
+    var worseNotiCycle: Double = 1 * 60 // 나쁜 자세 유지 시간(캐릭터 알림): 기본 값 1분
 }


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
캐릭터 알림 뜨는 시간이 너무 길었습니다.
### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
기존에 캐릭터 알림이 뜨는 시간인 3분에서 1분으로 수정했습니다.
### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
