### PR TITLE
[Fix] slideValue 계산 오류 해결

### DIFF
--- a/TurtleNeck/TurtleNeck/Presentation/Setting/SettingView.swift
+++ b/TurtleNeck/TurtleNeck/Presentation/Setting/SettingView.swift
@@ -424,14 +424,24 @@ extension SettingView {
         }
     }
     
+    // 슬라이더 값을 goodPostureRange로 변환하는 함수
+    private func convertSliderValueToRange(_ sliderValue: Double) -> Double {
+        // 슬라이더 한단계 값-> 0.03
+        // slideValue가 0일 때 0.04
+        return 0.04 + (sliderValue * 0.03)
+    }
+    
     /// 슬라이더 값에 따라 goodPostureRange값 조정
     private func updateGoodPostureRange() {
         // 슬라이더 한단계 값-> 0.05
-        let rangeAdjustment = (slideValue - 2) * 0.05
-        userManager.updateUser(keyPath: \.goodPostureRange, value: userManager.user.goodPostureRange + rangeAdjustment)
+//        let rangeAdjustment = (slideValue - 2) * 0.05
+        let newRange = convertSliderValueToRange(slideValue)
+        
+        userManager.updateUser(keyPath: \.goodPostureRange, value: newRange)
         print(userManager.user.goodPostureRange)
         userManager.saveUser()
         
+        print("goodPostureRange 업데이트됨! 현재 값: \(newRange)")
     }
 }
 


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
resolved: #104 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->

```swift
let rangeAdjustment = (slideValue - 2) * 0.05
```
- 이전 슬라이더값 계산식이 위와 같았는데 slideValue가 0~4라서, 0,1일 땐 무조건 값이 마이너스가 되고, 2일 땐 0이라 값이 바뀌지 않고.. 이런 문제가 있어서 민감도가 제대로 반영되지 않았어요!

#### 1. sliderValue에 설정값을 곱해줘서 더하는 계산식으로 변경

```swift
    private func convertSliderValueToRange(_ sliderValue: Double) -> Double {
        // 슬라이더 한단계 값-> 0.03
        // slideValue가 0일 때 0.04
        return 0.04 + (sliderValue * 0.03)
    }
```

- 슬라이더 한단계 값을 일단 0.03으로 변경해줬습니다.
- slideValue가 일 때 기본 0.04로 해주고, sliderValue에 따라 0.03씩 곱해줘서 더해줬습니다.

#### 2. 민감도값을 넣어주는 방식 수정
- 이전엔 아래와 같이 기존 goodPostureRange값을 직접 건드리는 방식이였다면,
```swift
value: userManager.user.goodPostureRange + rangeAdjustment
```
- 지금은 그냥 계산한 민감도값을 goodPostureRange에 바로 넣어주었습니다.
- (계산식에 의해 원본값이 이상하게 변경되는 것을 방지, 그냥 절대적인 민감도값을 바로 넣어줌)

```swift
let newRange = convertSliderValueToRange(slideValue)

userManager.updateUser(keyPath: \.goodPostureRange, value: newRange)
```


### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

- 혹시 의문점이 생긴다면 저에게 콜해주세요!!

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

- 이전에 motionManager의 user값이 바뀌지 않는 문제는.. 제 브랜치에 도란이 구조 수정한게 반영되지 않아 생긴 문제더라고요..ㅎㅎ
- 그건 문제 없음! 도란덕분에 해결 땡큐 ㅎㅎ 
- 그리고 슬라이더 구현하시느라 고생많으셨습다ㅎㅎ 감사요!!! 짜잘한 에러만 수정해줬어요

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
