### PR TITLE
[Fix] 자세 재설정 시 윈도우 창이 닫히는 에러 해결

### DIFF
--- a/TurtleNeck/TurtleNeck/Application/AppDelegate/AppDelegate.swift
+++ b/TurtleNeck/TurtleNeck/Application/AppDelegate/AppDelegate.swift
@@ -250,6 +250,8 @@ extension AppDelegate {
         newWindow.contentView = NSHostingView(rootView:
                                                 ContentView(isFromSetting: true)
             .environment(\.appDelegate, self)
+            .environmentObject(userManager)
+            .environmentObject(statisticManager)
             .background(.white))
         
         newWindow.delegate = self


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->

resolved: #109 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
#### 1. 마주한 에러

- 자세 재설정 시 MeasureReadyFirstView에서 다음을 누르면 아래와 같은 에러가 뜸
- 해당 뷰에서 userManager을 찾을 수 없다는 에러
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/3f2a6143-6e95-4b41-806b-05b68ce956f9" />


#### 2. openMeasureView()에 userManager을 주입해줬습니다.

- 현재 자세 재설정버튼을 누르면 **AppDelegate에서 openMeasureView()를 호출하는 방식**으로 윈도우를 열어줍니다.
```
// SettingView.swift
 Button {
                                    timerManager.resetTimer(statistics: &statisticManager.statistics)
                                    appDelegate?.openMeasureView() // 요기!
                                    NavigationManager.shared.navigateToRoot()
                                } label: {
...
```

- 해당 함수에서 **ContentView를 불러올 때 userManager을 주입**해줍니다.

 ```swift
// AppDelegate.swift
func openMeasureView() {
...
  newWindow.contentView = NSHostingView(rootView:
                                                ContentView(isFromSetting: true)
            .environment(\.appDelegate, self)
            .environmentObject(userManager) // 요기!
            .environmentObject(statisticManager)
,,,
```

#### 해결!

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

- isFirst 문젠줄 알았는데 아니였음ㅎㅎ..ㅎ
- openMeasureView 함수에서 바로 ContentView를 불러주니 isFirst의 참거짓 여부는 상관이 없었음!

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
