### PR TITLE
[Refactor] 최근 7일의 기록이 뜨게 수정

### DIFF
--- a/TurtleNeck/TurtleNeck/Application/AppDelegate/AppDelegate.swift
+++ b/TurtleNeck/TurtleNeck/Application/AppDelegate/AppDelegate.swift
@@ -223,6 +223,9 @@ extension AppDelegate {
         else{
             settingWindowController?.window?.makeKeyAndOrderFront(nil)
         }
+        
+        newWindow.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
     
     func openMeasureView() {

--- a/TurtleNeck/TurtleNeck/Application/AppDelegate/AppDelegate.swift
+++ b/TurtleNeck/TurtleNeck/Application/AppDelegate/AppDelegate.swift
@@ -203,7 +203,7 @@ extension AppDelegate {
         newWindow.backgroundColor = .white
         
         newWindow.center()
-        newWindow.level = .floating
+        newWindow.level = .normal
         newWindow.isMovableByWindowBackground = true
         newWindow.setFrameAutosaveName("SettingWindow")
         

--- a/TurtleNeck/TurtleNeck/Model/User.swift
+++ b/TurtleNeck/TurtleNeck/Model/User.swift
@@ -15,7 +15,7 @@ enum NotificationMode: Codable {
 struct User: Codable {
     var isFirst: Bool
     var goodPosture: Double?
-    var goodPostureRange : Double = 0.1 //약 5.7도
+    var goodPostureRange : Double = 0.157 //약 9도 (기본값)
     var disturbMode : Bool = false
     var notiCycle: Double = 10 //TODO: 10초 -> 10분으로 수정
     var notificationMode: NotificationMode = .default

--- a/TurtleNeck/TurtleNeck/Presentation/Main/Statistic/WeekPostureView.swift
+++ b/TurtleNeck/TurtleNeck/Presentation/Main/Statistic/WeekPostureView.swift
@@ -12,13 +12,13 @@ struct WeekPostureView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
-            Text("지난 7일간의 최고 기록")
+            Text("최근 7일간의 최고 기록")
                 .font(.tnBodyEmphasized12)
                 .foregroundColor(.black)
                 .padding(.top, 18)
             
             HStack(alignment: .bottom, spacing: 8) {
-                if filteredStatistics.count == 0 {
+                if past7DaysStatistics.count == 0 {
                     VStack(spacing: 0){
                         Image("CryingTurtle").resizable().scaledToFit().frame(width: 100,height: 100).padding(.top,8)
                         Text("측정된 데이터가 없어요.").font(.tnBodyRegular14).foregroundColor(.black)
@@ -29,7 +29,7 @@ struct WeekPostureView: View {
                     } .frame(width: 251).padding(.horizontal,14)
                 }
                 else {
-                    ForEach(filteredStatistics) { data in
+                    ForEach(past7DaysStatistics) { data in
                         let height = getHeightStatistic(day: data)
                         VStack(spacing: 2) {
                             if data.bestRecord == 0 {
@@ -104,11 +104,30 @@ extension WeekPostureView {
 }
 
 extension WeekPostureView {
-    // View에 보여주는 통계 중에 오늘의 데이터를 제외
-    private var filteredStatistics: [Statistic] {
+    // 최근 7일간의 통계 데이터 (오늘부터 7일 전까지)
+    private var past7DaysStatistics: [Statistic] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-        return statisticManager.statistics.filter { calendar.startOfDay(for: $0.date) < today }
+        let sevenDaysAgo = calendar.date(byAdding: .day, value: -6, to: today)!
+        
+        // 최근 7일 범위의 모든 날짜 생성
+        var past7Days: [Date] = []
+        for i in 0..<7 {
+            if let date = calendar.date(byAdding: .day, value: -i, to: today) {
+                past7Days.append(date)
+            }
+        }
+        past7Days.reverse() // 오래된 날짜부터 정렬
+        
+        // 각 날짜에 대해 기록이 있으면 해당 기록, 없으면 빈 기록 생성
+        return past7Days.map { date in
+            let dayStart = calendar.startOfDay(for: date)
+            if let existingRecord = statisticManager.statistics.first(where: { calendar.startOfDay(for: $0.date) == dayStart }) {
+                return existingRecord
+            } else {
+                return Statistic(date: date, time: 0, notiCount: 0, bestRecord: 0)
+            }
+        }
     }
 }
 

--- a/TurtleNeck/TurtleNeck/Presentation/Main/Statistic/WeekPostureView.swift
+++ b/TurtleNeck/TurtleNeck/Presentation/Main/Statistic/WeekPostureView.swift
@@ -74,7 +74,7 @@ struct WeekPostureView: View {
 
 extension WeekPostureView {
     private func getHeightStatistic(day: Statistic) -> Double {
-        guard let maxBestRecord = getMaxBestRecord(from: statisticManager.statistics) else {
+        guard let maxBestRecord = getMaxBestRecord(from: past7DaysStatistics) else {
             return 0
         }
 
@@ -82,17 +82,19 @@ extension WeekPostureView {
             return 0
         }
 
-        let calculatedHeight = Double(day.bestRecord) * (92 / Double(maxBestRecord))
+        // 최소 높이 10, 최대 높이 92로 설정
+        let minHeight = 10.0
+        let maxHeight = 92.0
+        let ratio = Double(day.bestRecord) / Double(maxBestRecord)
+        let calculatedHeight = minHeight + (ratio * (maxHeight - minHeight))
+        
         return calculatedHeight
     }
     
     private func getMaxBestRecord(from statistics: [Statistic]) -> Int? {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        
         return statistics
-            .filter { calendar.startOfDay(for: $0.date) < today }
             .map { $0.bestRecord }
+            .filter { $0 > 0 }  // 0보다 큰 값만 필터링
             .max()
     }
     

--- a/TurtleNeck/TurtleNeck/Presentation/Setting/SettingView.swift
+++ b/TurtleNeck/TurtleNeck/Presentation/Setting/SettingView.swift
@@ -12,7 +12,7 @@ struct SettingView: View {
     @EnvironmentObject private var statisticManager: StatisticManager
     @EnvironmentObject private var userManager: UserManager
     
-    // TODO: 민감도 조절 값으로 변경
+    // 민감도 조절 슬라이더 값 (기본값 2 = goodPostureRange 0.1)
     @State private var slideValue: Double = 2
     @ObservedObject var notificationManager: NotificationManager
     @ObservedObject var motionManager: HeadphoneMotionManager
@@ -407,6 +407,10 @@ struct SettingView: View {
         }
         .frame(width: 560, height: 788)
         .background(.white)
+        .onAppear {
+            // 현재 goodPostureRange 값을 기반으로 슬라이더 값 초기화
+            slideValue = convertRangeToSliderValue(userManager.user.goodPostureRange)
+        }
     }
 }
 
@@ -426,9 +430,18 @@ extension SettingView {
     
     // 슬라이더 값을 goodPostureRange로 변환하는 함수
     private func convertSliderValueToRange(_ sliderValue: Double) -> Double {
-        // 슬라이더 한단계 값-> 0.03
-        // slideValue가 0일 때 0.04
-        return 0.04 + (sliderValue * 0.03)
+        // 슬라이더 값에 따른 goodPostureRange 매핑
+        // 0: 3도(0.052), 1: 6도(0.105), 2: 9도(0.157), 3: 12도(0.209), 4: 15도(0.262)
+        let baseValue = 0.052
+        let increment = 0.053
+        return baseValue + (sliderValue * increment)
+    }
+    
+    // goodPostureRange 값을 슬라이더 값으로 역변환하는 함수
+    private func convertRangeToSliderValue(_ range: Double) -> Double {
+        let baseValue = 0.052
+        let increment = 0.053
+        return (range - baseValue) / increment
     }
     
     /// 슬라이더 값에 따라 goodPostureRange값 조정


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->

closed: #112 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->

#### 1. 최근 7일간의 기록이 뜨도록 수정
- 수정 전: 데이터가 있는 7일의 기록이 뜸
- 수정 후: 기록이 없어도, 최근 7일의 기록이 뜸

#### 2. 설정창이 최상단에만 위치하는 에러 수정
- 수정 전: 다른 창을 클릭해도, 설정창이 항상 최상단에 위치하였음
- 수정 후: 처음 설정창을 켰을 때, 설정창이 최상단에 뜸, 다른 창을 누르면 뒤로 감
    - 아래 두줄을 추가해줬습니다.
    - 설정창을 처음 열었을 때 한 번 맨 앞에 위치하게 설정해주는 코드입니다.

```swift
// AppDelegate.swift - openSettingView

// 창을 키 윈도우로 만들고 화면 앞에 표시함
newWindow.makeKeyAndOrderFront(nil)

// 현재 앱을 포그라운드로 전환시킴 (다른 앱 위로 가져옴)
NSApp.activate(ignoringOtherApps: true)
```

#### 3. 민감도 조정 각도 수정
- 민감도 슬라이더 값에 해당하는 각도 범위를 좀 더 넓혔습니다.
- 수정된 각도 값은 아래와 같습니다.

| 슬라이더 값 | 각도 | 라디안 값 |
|-------------|-----------|------------|
| 0           | 약 3°     | 0.052      |
| 1           | 약 6°     | 0.105      |
| 2 (기본값)  | 약 9°     | 0.157      |
| 3           | 약 12°    | 0.209      |
| 4           | 약 15°    | 0.262      |

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

<img width="300" height="218" alt="image" src="https://github.com/user-attachments/assets/ce882f49-5fd6-4ebe-8331-6f7df1137c17" />

#### 현재 기록이 너무 작으면 막대그래프 길이가 너무 작아져서 잘 안보이는 문제를 해결하기 위해
- 일단 기록이 하나만 있을 땐 max(92) 길이로 표시되고,
- 기록이 더 들어왔을 때, 막대의 길이는 최소 10, 최대 92 사이에서 비율을 기반으로 계산되어 표시됩니다.
오늘 이전 7일의 통계에서 비율을 계산해 막대 길이를 정하는 것!!
이 방법 괜춘할까요? 데이터가 하나일 때 길이가 너무 길어 너무 어색하면 다시 수정하께요!
